### PR TITLE
feat(web): add touch haptics for core gameplay interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Disclaimer: I do not own the Queen's Blood IP. This project is a fan-made implem
 - Added All Cards page as a card glossary
 - Added mobile-friendly interactions (tap to preview, then confirm)
 - Added live server-status indicator (online, waking, offline)
+- Added mobile/tablet haptic feedback for key game interactions
 
 ### Engineering
 
@@ -75,8 +76,8 @@ For two-device play on the same network, see `docs/local-network-setup.md`.
 
 ### Analytics events (PostHog)
 
-- Web: `site_visited`, `room_created`, `room_join_attempted`, `room_join_submitted`, `bot_game_started`, `bot_game_completed`, `rematch_requested`, `rematch_declined`
-- Server (when `POSTHOG_API_KEY` is set): `multiplayer_game_started`, `multiplayer_game_completed`
+- Web: `site_visited`, `server_offline_seen`, `sfx_toggled`, `room_created`, `room_join_attempted`, `room_join_submitted`, `ready_room_entered`, `ready_room_response`, `ready_room_match_started`, `session_match_started`, `bot_game_started`, `bot_game_completed`, `rematch_requested`, `rematch_declined`
+- Server (when `POSTHOG_API_KEY` is set): `multiplayer_game_started`, `multiplayer_game_completed` (`start_reason` is included on game started)
 
 ## Feature highlights
 
@@ -86,6 +87,16 @@ For two-device play on the same network, see `docs/local-network-setup.md`.
 - Play vs bot without running the server
 - Deck Builder and All Cards glossary
 - Responsive UI for desktop and mobile
+- Touch haptics for meaningful actions (selection, placement, success/error outcomes)
+
+## Haptics guidelines
+
+- Haptics are implemented with `web-haptics` and degrade silently on unsupported devices.
+- Trigger haptics only on high-value interactions and always pair with visual feedback.
+- Keep trigger meaning consistent:
+  - `selection`: discrete stepping interactions
+  - `light` / `medium` / `heavy`: impact intensity by action significance
+  - `success` / `warning` / `error`: async outcomes and status feedback
 
 ## UI snapshots
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "react-router-dom": "6.30.3",
     "socket.io-client": "4.8.3",
     "tailwind-merge": "^3.5.0",
+    "web-haptics": "^0.0.6",
     "zustand": "4.5.2"
   },
   "devDependencies": {

--- a/apps/web/src/components/Board.tsx
+++ b/apps/web/src/components/Board.tsx
@@ -21,6 +21,7 @@ import { cn } from '../utils/cn'
 import { useShallow } from 'zustand/react/shallow'
 import { calcPlayerScores } from '../utils/calcPlayerScores'
 import { TileEffectBadge } from './TileIndicator'
+import { useHaptics } from '../hooks/useHaptics'
 
 function ScoreCell({
   score,
@@ -124,6 +125,7 @@ export default function Board({
   const isMyTurn = useTurnStore((state) => state.isMyTurn)
   const isMobile = useIsMobile()
   const { confirmPlacement } = usePlaceCard()
+  const haptics = useHaptics()
 
   const { gameOver, setGameResult, playerOneName, playerTwoName, playerDisconnected } = useGameStore(useShallow((state) => ({ gameOver: state.gameOver, setGameResult: state.setGameResult, playerOneName: state.playerOneName, playerTwoName: state.playerTwoName, playerDisconnected: state.playerDisconnected })))
   const { playerOnePointsArray, playerTwoPointsArray } = usePointStore(useShallow(state => ({ playerOnePointsArray: state.playerOnePoints, playerTwoPointsArray: state.playerTwoPoints })))
@@ -202,10 +204,12 @@ export default function Board({
 
     if (!canPlace(position)) {
       playSynthSound('invalid')
+      haptics.warning()
       return
     }
 
     if (isMobile) {
+      haptics.selection()
       setPreviewTile([rowIndex, colIndex])
       return
     }

--- a/apps/web/src/components/Hand.tsx
+++ b/apps/web/src/components/Hand.tsx
@@ -8,6 +8,7 @@ import flickSound from '../assets/sounds/cardflick.mp3'
 import { playSound } from '../store/SoundStore'
 import { cn } from '../utils/cn'
 import { useIsMobile } from '../hooks/useIsMobile'
+import { useHaptics } from '../hooks/useHaptics'
 
 const flickAudio = new Audio(flickSound)
 const hoverAudio = new Audio(hoverSound)
@@ -17,13 +18,16 @@ export default function Hand() {
   const selectedCard = useCardStore((state) => state.selectedCard)
   const setSelectedCard = useCardStore((state) => state.setSelectedCard)
   const isMobile = useIsMobile()
+  const haptics = useHaptics()
 
   const handleCardClick = (card: CardUnity) => {
     if (selectedCard?.id === card.id) {
+      haptics.impactLight()
       setSelectedCard(null)
       return
     }
 
+    haptics.impactLight()
     setSelectedCard(card)
     playSound(flickAudio, 0.4)
   }

--- a/apps/web/src/components/Modals/EndGameModal.tsx
+++ b/apps/web/src/components/Modals/EndGameModal.tsx
@@ -2,16 +2,32 @@ import { m } from 'framer-motion'
 import { Fireworks } from '@fireworks-js/react'
 import type { FireworksHandlers } from '@fireworks-js/react'
 import { Result, useGameStore } from '../../store/GameStore'
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import explosion0 from '../../assets/sounds/explosion0.mp3'
 import explosion1 from '../../assets/sounds/explosion1.mp3'
 import explosion2 from '../../assets/sounds/explosion2.mp3'
 import useSoundStore from '../../store/SoundStore'
+import { useHaptics } from '../../hooks/useHaptics'
 
 export function EndGameModal() {
   const [gameResult] = useGameStore((state) => [state.gameResult])
   const [muted] = useSoundStore((state) => [state.muted])
   const ref = useRef<FireworksHandlers>(null)
+  const haptics = useHaptics()
+
+  useEffect(() => {
+    if (gameResult === Result.WIN) {
+      haptics.success()
+      return
+    }
+
+    if (gameResult === Result.LOSE) {
+      haptics.error()
+      return
+    }
+
+    haptics.impactMedium()
+  }, [gameResult, haptics])
 
   return (
     <m.div

--- a/apps/web/src/components/Modals/ReadyRoomDialog.tsx
+++ b/apps/web/src/components/Modals/ReadyRoomDialog.tsx
@@ -5,6 +5,8 @@ import socket from '../../socket'
 import { useNavigate, useParams } from 'react-router-dom'
 import Hourglass from '../Hourglass'
 import { cn } from '../../utils/cn'
+import { trackEvent } from '../../lib/analytics'
+import { useHaptics } from '../../hooks/useHaptics'
 
 function OpponentStatus({ status }: { status: RematchStatus }) {
   if (status === 'waiting') {
@@ -38,6 +40,7 @@ export function ReadyRoomDialog() {
     state.amIP1,
   ])
   const [hideReadyRoom] = useModalStore((state) => [state.hideReadyRoom])
+  const haptics = useHaptics()
 
   const myName = amIP1
     ? playerOneName || 'Player 1'
@@ -51,10 +54,18 @@ export function ReadyRoomDialog() {
 
   const handleReady = () => {
     const response = myStatus === 'confirmed' ? 'waiting' : 'confirmed'
+    if (response === 'confirmed') {
+      haptics.success()
+    } else {
+      haptics.impactLight()
+    }
+    trackEvent('ready_room_response', { response })
     socket.emit('ready-respond', { gameId, response })
   }
 
   const handleQuit = () => {
+    haptics.warning()
+    trackEvent('ready_room_response', { response: 'refused' })
     socket.emit('ready-respond', { gameId, response: 'refused' })
     hideReadyRoom()
     socket.disconnect()

--- a/apps/web/src/components/Modals/RematchDialog.tsx
+++ b/apps/web/src/components/Modals/RematchDialog.tsx
@@ -18,6 +18,7 @@ import explosion1 from '../../assets/sounds/explosion1.mp3'
 import explosion2 from '../../assets/sounds/explosion2.mp3'
 import useSoundStore from '../../store/SoundStore'
 import { trackEvent } from '../../lib/analytics'
+import { useHaptics } from '../../hooks/useHaptics'
 
 function OpponentStatus({ status }: { status: RematchStatus }) {
   if (status === 'waiting') {
@@ -54,6 +55,7 @@ export function RematchDialog() {
   const [hideRematchDialog] = useModalStore((state) => [
     state.hideRematchDialog,
   ])
+  const haptics = useHaptics()
   const fireworksRef = useRef<FireworksHandlers>(null)
   const { playerOnePointsArray, playerTwoPointsArray } = usePointStore(useShallow(state => ({ playerOnePointsArray: state.playerOnePoints, playerTwoPointsArray: state.playerTwoPoints })))
 
@@ -77,6 +79,7 @@ export function RematchDialog() {
     : playerOneName || 'Player 1'
 
   const handleRematch = () => {
+    haptics.success()
     trackEvent('rematch_requested', { mode: botActions ? 'bot' : 'multiplayer' })
     if (botActions) {
       botActions.rematchRespond('confirmed')
@@ -86,6 +89,7 @@ export function RematchDialog() {
   }
 
   const handleQuit = () => {
+    haptics.warning()
     trackEvent('rematch_declined', { mode: botActions ? 'bot' : 'multiplayer' })
     if (botActions) {
       hideRematchDialog()

--- a/apps/web/src/components/SkipTurn.tsx
+++ b/apps/web/src/components/SkipTurn.tsx
@@ -6,10 +6,12 @@ import useTurnStore from '../store/TurnStore'
 import { useParams } from 'react-router-dom'
 import { useBotGameActions } from '../contexts/BotGameContext'
 import { useShallow } from 'zustand/react/shallow'
+import { useHaptics } from '../hooks/useHaptics'
 
 export default function SkipTurn() {
   const { isMyTurn, playerSkippedTurn } = useTurnStore(useShallow((state) => ({ isMyTurn: state.isMyTurn, playerSkippedTurn: state.playerSkippedTurn })))
   const botActions = useBotGameActions()
+  const haptics = useHaptics()
 
   const resetSelectedCard = useCardStore((state) => state.resetSelectedCard)
 
@@ -18,6 +20,7 @@ export default function SkipTurn() {
   const { id: gameId } = useParams<{ id: string }>()
 
   function handleSkipTurn() {
+    haptics.impactMedium()
     resetSelectedCard()
     if (botActions) {
       botActions.skipTurn()

--- a/apps/web/src/hooks/useHaptics.ts
+++ b/apps/web/src/hooks/useHaptics.ts
@@ -1,0 +1,63 @@
+import { useCallback, useMemo, useSyncExternalStore } from 'react'
+import { useWebHaptics } from 'web-haptics/react'
+
+type HapticTrigger =
+  | 'success'
+  | 'warning'
+  | 'error'
+  | 'light'
+  | 'medium'
+  | 'heavy'
+  | 'selection'
+
+const TOUCH_POINTER_QUERY = '(pointer: coarse)'
+
+function getServerSnapshot() {
+  return false
+}
+
+function getSnapshot() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false
+  }
+  return window.matchMedia(TOUCH_POINTER_QUERY).matches
+}
+
+function subscribe(callback: () => void) {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return () => {}
+  }
+
+  const mql = window.matchMedia(TOUCH_POINTER_QUERY)
+  mql.addEventListener('change', callback)
+  return () => mql.removeEventListener('change', callback)
+}
+
+export function useHaptics() {
+  const haptics = useWebHaptics()
+  const isTouchPointer = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+
+  const trigger = useCallback((type?: HapticTrigger) => {
+    if (!isTouchPointer) return
+    haptics.trigger(type)
+  }, [haptics, isTouchPointer])
+
+  const impactLight = useCallback(() => trigger('light'), [trigger])
+  const impactMedium = useCallback(() => trigger('medium'), [trigger])
+  const impactHeavy = useCallback(() => trigger('heavy'), [trigger])
+  const selection = useCallback(() => trigger('selection'), [trigger])
+  const success = useCallback(() => trigger('success'), [trigger])
+  const warning = useCallback(() => trigger('warning'), [trigger])
+  const error = useCallback(() => trigger('error'), [trigger])
+
+  return useMemo(() => ({
+    trigger,
+    impactLight,
+    impactMedium,
+    impactHeavy,
+    selection,
+    success,
+    warning,
+    error,
+  }), [trigger, impactLight, impactMedium, impactHeavy, selection, success, warning, error])
+}

--- a/apps/web/src/hooks/usePlaceCard.ts
+++ b/apps/web/src/hooks/usePlaceCard.ts
@@ -4,6 +4,7 @@ import useTurnStore from '../store/TurnStore'
 import { useBotGameActions } from '../contexts/BotGameContext'
 import socket from '../socket'
 import { useParams } from 'react-router-dom'
+import { useHaptics } from './useHaptics'
 
 export function usePlaceCard() {
   const selectedCard = useCardStore((state) => state.selectedCard)
@@ -13,6 +14,7 @@ export function usePlaceCard() {
   const isMyTurn = useTurnStore((state) => state.isMyTurn)
   const botActions = useBotGameActions()
   const { id: gameId } = useParams<{ id: string }>()
+  const haptics = useHaptics()
 
   function confirmPlacement(rowIndex: number, colIndex: number) {
     if (!selectedCard) return
@@ -23,11 +25,13 @@ export function usePlaceCard() {
 
     if (botActions) {
       botActions.placeCard(selectedCard.id, rowIndex, correctColIndex)
+      haptics.impactMedium()
       resetSelectedCard()
       return
     }
 
     placeCard(selectedCard)
+    haptics.impactMedium()
     resetSelectedCard()
 
     socket.emit('place-card', {

--- a/apps/web/src/pages/Game/index.tsx
+++ b/apps/web/src/pages/Game/index.tsx
@@ -23,6 +23,8 @@ import { useBotGame } from '../../hooks/useBotGame'
 import { BotGameContext } from '../../contexts/BotGameContext'
 import useCardStore from '../../store/CardStore'
 import PlaceCardButton from '../../components/PlaceCardButton'
+import { trackEvent, trackSessionMatchStarted } from '../../lib/analytics'
+import { useHaptics } from '../../hooks/useHaptics'
 
 export default function Game() {
   const { id: gameId } = useParams<{ id: string }>()
@@ -59,6 +61,8 @@ export default function Game() {
   const navigate = useNavigate()
   const [showEndGame, setShowEndGame] = useState(false)
   const endGameTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const multiplayerMatchCountRef = useRef(0)
+  const haptics = useHaptics()
 
   const gameStartModal = useModalStore((s) => s.gameStartModal)
   const toggleGameStartModal = useModalStore((s) => s.toggleGameStartModal)
@@ -91,6 +95,11 @@ export default function Game() {
       initialHand: CardUnity[];
       isPlayerOne: boolean;
     }) => {
+      const startReason = multiplayerMatchCountRef.current === 0 ? 'initial' : 'rematch'
+      trackSessionMatchStarted('multiplayer')
+      trackEvent('ready_room_match_started', { start_reason: startReason })
+      multiplayerMatchCountRef.current += 1
+
       // Reset for rematch if game was over
       if (endGameTimerRef.current) {
         clearTimeout(endGameTimerRef.current)
@@ -131,6 +140,7 @@ export default function Game() {
       if (data.drawnCard) {
         addCard(data.drawnCard)
       }
+      haptics.selection()
       toggleTurnModal()
       toggleTurn()
     })
@@ -175,11 +185,15 @@ export default function Game() {
     })
 
     socket.on('game-busy', () => {
+      haptics.error()
       setLoading(false)
       setGameBusy(true)
     })
 
     socket.on('ready-room', (data: { playerNames: string[], isPlayerOne: boolean }) => {
+      trackEvent('ready_room_entered', {
+        is_player_one: data.isPlayerOne,
+      })
       setPlayerOneName(data.playerNames[0])
       setPlayerTwoName(data.playerNames[1])
       setAmIP1(data.isPlayerOne)
@@ -221,7 +235,35 @@ export default function Game() {
       socket.off('ready-player-left')
       if (endGameTimerRef.current) clearTimeout(endGameTimerRef.current)
     }
-  }, [])
+  }, [
+    addCard,
+    hideReadyRoom,
+    hideRematchDialog,
+    haptics,
+    navigate,
+    resetBoardStore,
+    resetCardStore,
+    resetNeoHandStore,
+    resetPointsStore,
+    resetPreviewTile,
+    resetTurnStore,
+    setAmIP1,
+    setBoard,
+    setGameOver,
+    setHand,
+    setPlayerDisconnected,
+    setPlayerOneName,
+    setPlayerSkippedTurn,
+    setPlayerTwoName,
+    setPoints,
+    setReadyStatuses,
+    setRematchStatuses,
+    showReadyRoom,
+    showRematchDialog,
+    toggleGameStartModal,
+    toggleTurn,
+    toggleTurnModal,
+  ])
 
   const handleGameIdClick = async (gameId?: string) => {
     try {

--- a/apps/web/src/pages/Game/index.tsx
+++ b/apps/web/src/pages/Game/index.tsx
@@ -63,6 +63,8 @@ export default function Game() {
   const endGameTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const multiplayerMatchCountRef = useRef(0)
   const haptics = useHaptics()
+  const hapticsRef = useRef(haptics)
+  useEffect(() => { hapticsRef.current = haptics }, [haptics])
 
   const gameStartModal = useModalStore((s) => s.gameStartModal)
   const toggleGameStartModal = useModalStore((s) => s.toggleGameStartModal)
@@ -140,7 +142,7 @@ export default function Game() {
       if (data.drawnCard) {
         addCard(data.drawnCard)
       }
-      haptics.selection()
+      hapticsRef.current.selection()
       toggleTurnModal()
       toggleTurn()
     })
@@ -185,7 +187,7 @@ export default function Game() {
     })
 
     socket.on('game-busy', () => {
-      haptics.error()
+      hapticsRef.current.error()
       setLoading(false)
       setGameBusy(true)
     })
@@ -239,7 +241,6 @@ export default function Game() {
     addCard,
     hideReadyRoom,
     hideRematchDialog,
-    haptics,
     navigate,
     resetBoardStore,
     resetCardStore,

--- a/apps/web/src/pages/Home/index.tsx
+++ b/apps/web/src/pages/Home/index.tsx
@@ -3,6 +3,7 @@ import socket, { connectSocket } from '../../socket'
 import { useEffect, useState } from 'react'
 import { useServerHealth } from '../../hooks/useServerHealth'
 import { trackEvent } from '../../lib/analytics'
+import { useHaptics } from '../../hooks/useHaptics'
 
 export default function Home() {
   const navigate = useNavigate()
@@ -12,21 +13,26 @@ export default function Home() {
   const [connecting, setConnecting] = useState(false)
   const { isOnline } = useServerHealth()
   const multiplayerDisabled = connecting || !isOnline
+  const haptics = useHaptics()
 
   useEffect(() => {
     socket.on('game-busy', () => {
+      haptics.error()
       setErrorMessage('Game is busy')
     })
 
     socket.on('game-not-found', () => {
+      haptics.error()
       setErrorMessage('Game not found')
     })
 
     socket.on('game-found', (data: { gameIdFound: string }) => {
+      haptics.success()
       navigate(`/waiting-room/${data.gameIdFound}`)
     })
 
     socket.on('game-created', (data: { gameId: string }) => {
+      haptics.success()
       navigate(`/game/${data.gameId}`)
     })
 
@@ -36,10 +42,11 @@ export default function Home() {
       socket.off('game-busy')
       socket.off('game-created')
     }
-  }, [])
+  }, [haptics, navigate])
 
   const handleStartGame = async () => {
     if (!playerName.trim()) {
+      haptics.error()
       setErrorMessage('Please enter your name')
       return
     }
@@ -50,6 +57,7 @@ export default function Home() {
       trackEvent('room_created')
       socket.emit('create-game', { playerName: playerName.trim() })
     } catch {
+      haptics.error()
       setErrorMessage('Could not connect to server. Please try again.')
     } finally {
       setConnecting(false)
@@ -57,6 +65,7 @@ export default function Home() {
   }
 
   const handleStartBotGame = () => {
+    haptics.impactMedium()
     navigate('/game/bot', {
       state: { playerName: playerName || 'Player' },
     })
@@ -70,6 +79,7 @@ export default function Home() {
       trackEvent('room_join_attempted', { game_id_length: gameId.trim().length })
       socket.emit('attempt-to-join-game', { gameId })
     } catch {
+      haptics.error()
       setErrorMessage('Could not connect to server. Please try again.')
     } finally {
       setConnecting(false)

--- a/apps/web/src/pages/WaitingRoom/index.tsx
+++ b/apps/web/src/pages/WaitingRoom/index.tsx
@@ -2,13 +2,16 @@ import { useNavigate, useParams } from 'react-router-dom'
 import socket from '../../socket'
 import { useState } from 'react'
 import { trackEvent } from '../../lib/analytics'
+import { useHaptics } from '../../hooks/useHaptics'
 
 export function WaitingRoom() {
   const [playerName, setPlayerName] = useState<string>('')
   const navigate = useNavigate()
   const { id: gameId } = useParams<{ id: string }>()
+  const haptics = useHaptics()
 
   const handleJoinGame = () => {
+    haptics.impactMedium()
     trackEvent('room_join_submitted')
     navigate(`/game/${gameId}`, { state: { joining: true } })
     socket.emit('join-game', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       ],
       "devDependencies": {
         "concurrently": "9.2.1",
+        "eslint": "^9.8.0",
         "turbo": "2.4.4"
       }
     },
@@ -69,6 +70,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -106,6 +108,7 @@
         "react-router-dom": "6.30.3",
         "socket.io-client": "4.8.3",
         "tailwind-merge": "^3.5.0",
+        "web-haptics": "^0.0.6",
         "zustand": "4.5.2"
       },
       "devDependencies": {
@@ -125,40 +128,6 @@
         "vite": "6.4.1"
       }
     },
-    "apps/web/node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.5",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "apps/web/node_modules/@eslint/js": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.8.0.tgz",
-      "integrity": "sha512-MfluB7EUfxXtv3i/++oh89uzAr4PDI4nn201hsp+qaXqsjAWzinlZEHEfPgAX4doIlKvPG/i0A9dpKxOLII8yA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
     "apps/web/node_modules/@fireworks-js/react": {
       "version": "2.10.7",
       "resolved": "https://registry.npmjs.org/@fireworks-js/react/-/react-2.10.7.tgz",
@@ -176,8 +145,8 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -220,149 +189,11 @@
         "postcss": "^8.1.0"
       }
     },
-    "apps/web/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "apps/web/node_modules/eslint": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.8.0.tgz",
-      "integrity": "sha512-K8qnZ/QJzT2dLKdZJVX6W4XOwBzutMYmt0lqUS+JdXgd+HTYFlonFgkJ8s44d/zMPPCnOOk0kMWCApCPhiOy9A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.11.0",
-        "@eslint/config-array": "^0.17.1",
-        "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.8.0",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.3.0",
-        "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.12.4",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
-        "debug": "^4.3.2",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.0.2",
-        "eslint-visitor-keys": "^4.0.0",
-        "espree": "^10.1.0",
-        "esquery": "^1.5.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      }
-    },
-    "apps/web/node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "apps/web/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "apps/web/node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "apps/web/node_modules/file-entry-cache": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flat-cache": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "apps/web/node_modules/fireworks-js": {
       "version": "2.10.7",
       "resolved": "https://registry.npmjs.org/fireworks-js/-/fireworks-js-2.10.7.tgz",
       "integrity": "sha512-FyRNiqlgu9ZeFCjfN0UiGUlj5dUWNYLyFaWN/Q8sOMf0E+KGA4dMROaBZpCtym85fChgCspoa3jHoLTRZiy74A==",
       "license": "MIT"
-    },
-    "apps/web/node_modules/flat-cache": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flatted": "^3.2.9",
-        "keyv": "^4.5.4"
-      },
-      "engines": {
-        "node": ">=16"
-      }
     },
     "apps/web/node_modules/fraction.js": {
       "version": "4.3.7",
@@ -378,19 +209,6 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
-    "apps/web/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "apps/web/node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -399,19 +217,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "apps/web/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "apps/web/node_modules/postcss": {
@@ -434,6 +239,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -497,6 +303,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -652,6 +459,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1440,28 +1248,38 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
       },
       "engines": {
-        "node": "*"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.8.0.tgz",
+      "integrity": "sha512-MfluB7EUfxXtv3i/++oh89uzAr4PDI4nn201hsp+qaXqsjAWzinlZEHEfPgAX4doIlKvPG/i0A9dpKxOLII8yA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -1889,6 +1707,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3174,6 +2993,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -3465,43 +3285,6 @@
         }
       }
     },
-    "node_modules/@rocketseat/eslint-config/node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.5",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@rocketseat/eslint-config/node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@rocketseat/eslint-config/node_modules/@eslint/js": {
       "version": "9.39.4",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
@@ -3515,154 +3298,6 @@
         "url": "https://eslint.org/donate"
       }
     },
-    "node_modules/@rocketseat/eslint-config/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@rocketseat/eslint-config/node_modules/eslint": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.8.0.tgz",
-      "integrity": "sha512-K8qnZ/QJzT2dLKdZJVX6W4XOwBzutMYmt0lqUS+JdXgd+HTYFlonFgkJ8s44d/zMPPCnOOk0kMWCApCPhiOy9A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.11.0",
-        "@eslint/config-array": "^0.17.1",
-        "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.8.0",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.3.0",
-        "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.12.4",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
-        "debug": "^4.3.2",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.0.2",
-        "eslint-visitor-keys": "^4.0.0",
-        "espree": "^10.1.0",
-        "esquery": "^1.5.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      }
-    },
-    "node_modules/@rocketseat/eslint-config/node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@rocketseat/eslint-config/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@rocketseat/eslint-config/node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.8.0.tgz",
-      "integrity": "sha512-MfluB7EUfxXtv3i/++oh89uzAr4PDI4nn201hsp+qaXqsjAWzinlZEHEfPgAX4doIlKvPG/i0A9dpKxOLII8yA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@rocketseat/eslint-config/node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@rocketseat/eslint-config/node_modules/file-entry-cache": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flat-cache": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@rocketseat/eslint-config/node_modules/flat-cache": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flatted": "^3.2.9",
-        "keyv": "^4.5.4"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/@rocketseat/eslint-config/node_modules/globals": {
       "version": "15.15.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
@@ -3674,19 +3309,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@rocketseat/eslint-config/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@rocketseat/eslint-config/node_modules/neostandard": {
@@ -4469,24 +4091,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@stylistic/eslint-plugin/node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@stylistic/eslint-plugin/node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -4709,6 +4313,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5118,6 +4723,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5539,6 +5145,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -5571,6 +5188,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5988,7 +5606,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -6527,6 +6144,59 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.8.0.tgz",
+      "integrity": "sha512-K8qnZ/QJzT2dLKdZJVX6W4XOwBzutMYmt0lqUS+JdXgd+HTYFlonFgkJ8s44d/zMPPCnOOk0kMWCApCPhiOy9A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.11.0",
+        "@eslint/config-array": "^0.17.1",
+        "@eslint/eslintrc": "^3.1.0",
+        "@eslint/js": "9.8.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.3.0",
+        "@nodelib/fs.walk": "^1.2.8",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.0.2",
+        "eslint-visitor-keys": "^4.0.0",
+        "espree": "^10.1.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
     "node_modules/eslint-compat-utils": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
@@ -6683,6 +6353,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -6710,17 +6381,6 @@
         "eslint": ">=8.40"
       }
     },
-    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -6732,19 +6392,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
@@ -6781,6 +6428,23 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
@@ -6789,6 +6453,50 @@
       "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -7139,6 +6847,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -7181,6 +6902,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/flatted": {
@@ -7425,6 +7160,19 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
@@ -8548,6 +8296,7 @@
       "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.39.2.tgz",
       "integrity": "sha512-VcrisGRt+OI7tTPrziucJoCIPYIS/DEWY37TqzQVLWSUUHiyvsiRizEypQ3FOlhfIZ4ytAG/Mw4zxfetCTyKUg==",
       "license": "MPL-2.0",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -8630,6 +8379,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/minimist": {
@@ -9258,6 +9020,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9567,8 +9330,8 @@
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
       "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9874,8 +9637,9 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -10013,6 +9777,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10836,6 +10601,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11162,6 +10928,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11229,6 +10996,7 @@
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -11548,6 +11316,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -12125,6 +11894,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12240,6 +12010,32 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/web-haptics": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/web-haptics/-/web-haptics-0.0.6.tgz",
+      "integrity": "sha512-eCzcf1LDi20+Fr0x9V3OkX92k0gxEQXaHajmhXHitsnk6SxPeshv8TBtBRqxyst8HI1uf2FyFVE7QS3jo1gkrw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18",
+        "svelte": ">=4",
+        "vue": ">=3"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/web-vitals": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
@@ -12257,6 +12053,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "concurrently": "9.2.1",
+    "eslint": "^9.8.0",
     "turbo": "2.4.4"
   }
 }


### PR DESCRIPTION
## Summary
- integrate `web-haptics` with a shared `useHaptics` wrapper that gates triggers to touch/coarse pointers for mobile/tablet-focused behavior
- add haptic feedback to core gameplay interactions and outcomes (selection, placement, skip turn, ready/rematch actions, and success/error states on home/game flows)
- document haptics usage guidelines in the README and ensure lint command resolves `eslint` from the monorepo root

## Testing
- `npm run build -w @queens-blood/web`
- `npm run lint -w @queens-blood/web` *(runs now, but currently reports existing style violations across unrelated files)*